### PR TITLE
Initial loading of datasources from yaml configuration file.

### DIFF
--- a/env-monitor/env-monitor-common/pom.xml
+++ b/env-monitor/env-monitor-common/pom.xml
@@ -29,9 +29,16 @@
             <version>${com.google.code.findbugs.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>${org.codehaus.jackson.version}</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.jcraft</groupId>

--- a/env-monitor/env-monitor-common/src/main/java/org/envtools/monitor/common/serialization/JacksonJSONSerializer.java
+++ b/env-monitor/env-monitor-common/src/main/java/org/envtools/monitor/common/serialization/JacksonJSONSerializer.java
@@ -1,9 +1,8 @@
 package org.envtools.monitor.common.serialization;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import org.apache.log4j.Logger;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ObjectWriter;
-
 import java.io.IOException;
 import java.io.Serializable;
 

--- a/env-monitor/env-monitor-model/pom.xml
+++ b/env-monitor/env-monitor-model/pom.xml
@@ -18,30 +18,46 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
+        <!-- validation API for DAO -->
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>${validation-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate-validator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+            <version>${javax.el.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>${javax.el.version}</version>
+        </dependency>
+        <!-- end of validation API for DAO -->
+
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>${commons-lang.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            <version>${org.codehaus.jackson.version}</version>
-        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${com.fasterxml.jackson.core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${com.fasterxml.jackson.core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${com.fasterxml.jackson.core.version}</version>
         </dependency>
 
         <dependency>

--- a/env-monitor/env-monitor-model/src/main/java/org/envtools/monitor/model/querylibrary/db/DataSource.java
+++ b/env-monitor/env-monitor-model/src/main/java/org/envtools/monitor/model/querylibrary/db/DataSource.java
@@ -1,11 +1,18 @@
 package org.envtools.monitor.model.querylibrary.db;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.envtools.monitor.model.querylibrary.DataProviderType;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Entity
 @Table(name = "DATA_SOURCE")
@@ -15,14 +22,17 @@ public class DataSource extends AbstractDbIdentifiable {
     }
 
     @Enumerated(EnumType.STRING)
+    @NotNull
     private DataProviderType type;
 
+    @NotEmpty
     private String name;
     private String description;
 
     /*dataSource 1 ко многим с сущностью DataSourceProperty*/
     @OneToMany(mappedBy = "dataSource", cascade = CascadeType.ALL)
     @OrderBy(value = "property")
+    @JsonProperty("properties")
     private List<DataSourceProperty> dataSourceProperties;
 
     @OneToMany(mappedBy = "dataSource", cascade = CascadeType.ALL)
@@ -79,4 +89,16 @@ public class DataSource extends AbstractDbIdentifiable {
                 .append("queryExecutions", queryExecutions)
                 .toString();
     }
+
+    @JsonAnySetter
+    public void set(String name, Object value) {
+        DataSourceProperty dataSourceProperty = new DataSourceProperty();
+        dataSourceProperty.setProperty(name);
+        dataSourceProperty.setValue(value.toString());
+        if (dataSourceProperties == null) {
+            dataSourceProperties = new ArrayList<>();
+        }
+        dataSourceProperties.add(dataSourceProperty);
+    }
+
 }

--- a/env-monitor/env-monitor-module/pom.xml
+++ b/env-monitor/env-monitor-module/pom.xml
@@ -101,32 +101,20 @@
             <version>${commons-dbcp.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${com.fasterxml.jackson.core.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${com.fasterxml.jackson.core.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${com.fasterxml.jackson.core.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>${org.codehaus.jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            <version>${org.codehaus.jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>

--- a/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/AbstractPluggableModule.java
+++ b/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/AbstractPluggableModule.java
@@ -1,7 +1,7 @@
 package org.envtools.monitor.module;
 
 import org.apache.log4j.Logger;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.envtools.monitor.model.messaging.RequestMessage;
 import org.envtools.monitor.model.messaging.RequestPayload;
 import org.envtools.monitor.model.messaging.ResponseMessage;

--- a/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/applications/DaoConfiguration.java
+++ b/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/applications/DaoConfiguration.java
@@ -1,0 +1,19 @@
+package org.envtools.monitor.module.applications;
+
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import javax.validation.Validator;
+
+/**
+ * Created by IAvdeev on 17.01.2017.
+ */
+@Configuration
+public class DaoConfiguration {
+    @Bean
+    public Validator localValidatorFactoryBean() {
+        return new LocalValidatorFactoryBean();
+    }
+}

--- a/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/core/json/JSONRequestMessageParser.java
+++ b/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/core/json/JSONRequestMessageParser.java
@@ -1,6 +1,6 @@
 package org.envtools.monitor.module.core.json;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.envtools.monitor.model.messaging.RequestMessage;
 
 import java.io.IOException;

--- a/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/querylibrary/QueryLibraryModule.java
+++ b/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/querylibrary/QueryLibraryModule.java
@@ -1,6 +1,7 @@
 package org.envtools.monitor.module.querylibrary;
 
 import org.apache.log4j.Logger;
+import org.apache.tomcat.jdbc.pool.DataSource;
 import org.envtools.monitor.common.serialization.Serializer;
 import org.envtools.monitor.model.messaging.RequestMessage;
 import org.envtools.monitor.model.messaging.ResponseMessage;
@@ -12,6 +13,7 @@ import org.envtools.monitor.model.querylibrary.updates.DataOperation;
 import org.envtools.monitor.module.AbstractPluggableModule;
 import org.envtools.monitor.module.ModuleConstants;
 import org.envtools.monitor.module.querylibrary.services.*;
+import org.envtools.monitor.module.querylibrary.services.bootstrap.DataSourcesBootstrapService;
 import org.envtools.monitor.module.querylibrary.services.impl.updates.TreeUpdateTask;
 import org.envtools.monitor.module.querylibrary.viewmapper.QueryExecutionResultViewMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,6 +79,9 @@ public class QueryLibraryModule extends AbstractPluggableModule {
     @Resource(name = "querylibrary.bootstrapper")
     BootstrapService treeBootstrapService;
 
+    @Autowired
+    DataSourcesBootstrapService dataSourcesBootstrapService;
+
     @Override
     protected <T> void processPayload(T payload, RequestMessage requestMessage)  {
         if (payload instanceof QueryExecutionRequest) {
@@ -126,7 +131,11 @@ public class QueryLibraryModule extends AbstractPluggableModule {
     public void init() throws Exception {
         super.init();
 
+        // load initial set of queries
         treeBootstrapService.bootstrap();
+
+        // load set of sources
+        dataSourcesBootstrapService.bootstrapDataSources();
 
         TreeUpdateTask treeUpdateTask = new TreeUpdateTask(treeUpdateTriggerService, treeUpdateService);
         executorService.execute(treeUpdateTask);

--- a/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/querylibrary/dao/DataSourceDao.java
+++ b/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/querylibrary/dao/DataSourceDao.java
@@ -11,4 +11,12 @@ public interface DataSourceDao extends Dao<DataSource, Long> {
 
     List<DataSource> getNameByText(String text);
 
+    /**
+     * Get DataSource by exact name
+     *
+     * @param name
+     * @return
+     */
+    DataSource getByName(String name);
+
 }

--- a/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/querylibrary/dao/impl/DataSourceDaoImpl.java
+++ b/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/querylibrary/dao/impl/DataSourceDaoImpl.java
@@ -32,6 +32,14 @@ public class DataSourceDaoImpl extends AbstractDbDao<DataSource, Long> implement
                 .getResultList();
     }
 
+    @Override
+    public DataSource getByName(String name) {
+        List<DataSource> list = em.createQuery("FROM DataSource WHERE name = :name")
+                .setParameter("name", name)
+                .getResultList();
+        return list.size() == 1 ? list.get(0) : null;
+    }
+
     private String createPatternString(String text) {
         return "%" + text + "%";
     }

--- a/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/querylibrary/services/bootstrap/DataSourcesBootstrapService.java
+++ b/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/querylibrary/services/bootstrap/DataSourcesBootstrapService.java
@@ -1,0 +1,55 @@
+package org.envtools.monitor.module.querylibrary.services.bootstrap;
+
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.envtools.monitor.model.querylibrary.db.DataSource;
+import org.envtools.monitor.module.querylibrary.dao.DataSourceDao;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Reads a list of datasources available for queries from yaml file and saves it to database.
+ */
+@Service
+@Transactional
+public class DataSourcesBootstrapService {
+
+    private Resource yamlSource;
+
+    private DataSourceDao dataSourceDao;
+
+    @Autowired
+    public DataSourcesBootstrapService(@Value("${querylibrary.data_sources_bootstrapper.location:}") Resource yamlSource,
+                                       DataSourceDao dataSourceDao) {
+        this.yamlSource = yamlSource;
+        this.dataSourceDao = dataSourceDao;
+    }
+
+    /**
+     * Reads an yaml file with datasources and saves it to database
+     *
+     * @throws IOException when there is problem reading yaml file
+     * @throws ConstraintViolation when there is missing properties for datasource
+     */
+    public void bootstrapDataSources() throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true);
+        DataSource[] sources = mapper.readValue(yamlSource.getFile(), DataSource[].class);
+
+        dataSourceDao.save(Arrays.asList(sources));
+    }
+}

--- a/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/querylibrary/viewmapper/impl/DefaultCategoryViewMapper.java
+++ b/env-monitor/env-monitor-module/src/main/java/org/envtools/monitor/module/querylibrary/viewmapper/impl/DefaultCategoryViewMapper.java
@@ -1,8 +1,8 @@
 package org.envtools.monitor.module.querylibrary.viewmapper.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.envtools.monitor.model.querylibrary.db.*;
 import org.envtools.monitor.model.querylibrary.tree.view.*;
 import org.envtools.monitor.module.querylibrary.viewmapper.CategoryViewMapper;

--- a/env-monitor/env-monitor-module/src/test/java/org/envtools/monitor/module/querylibrary/PersistenceTestApplication.java
+++ b/env-monitor/env-monitor-module/src/test/java/org/envtools/monitor/module/querylibrary/PersistenceTestApplication.java
@@ -17,7 +17,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @ComponentScan(basePackages = "org.envtools.*")
 @EnableJpaRepositories("org.envtools.monitor.module.querylibrary.repo.*")
 @EntityScan(basePackageClasses = {LibQuery.class, Category.class, DataSource.class, DataSourceProperty.class,
-        QueryExecution.class, QueryExecutionParam.class, QueryParam.class})
+        QueryExecution.class, QueryExecutionParam.class, QueryParam.class })
 @EnableAutoConfiguration
 public class PersistenceTestApplication {
 }

--- a/env-monitor/env-monitor-module/src/test/java/org/envtools/monitor/module/querylibrary/services/bootstrap/DataSourcesBootstrapServiceIT.java
+++ b/env-monitor/env-monitor-module/src/test/java/org/envtools/monitor/module/querylibrary/services/bootstrap/DataSourcesBootstrapServiceIT.java
@@ -1,0 +1,66 @@
+package org.envtools.monitor.module.querylibrary.services.bootstrap;
+
+import org.envtools.monitor.model.querylibrary.DataProviderType;
+import org.envtools.monitor.model.querylibrary.db.DataSource;
+import org.envtools.monitor.model.querylibrary.db.DataSourceProperty;
+import org.envtools.monitor.module.querylibrary.PersistenceTestApplication;
+import org.envtools.monitor.module.querylibrary.dao.DataSourceDao;
+import org.envtools.monitor.module.querylibrary.dao.LibQueryDao;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.transaction.Transactional;
+import javax.validation.ConstraintViolationException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Created by IAvdeev on 16.01.2017.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = { PersistenceTestApplication.class })
+@TestPropertySource(locations = {"classpath:/persistence/application-persistence-test.properties"})
+@Transactional
+public class DataSourcesBootstrapServiceIT {
+
+    @Autowired
+    DataSourceDao dataSourceDao;
+
+    @Autowired
+    LibQueryDao queryDao;
+
+    @Test
+    public void testBootstrapDataSources() throws Exception {
+        DataSourcesBootstrapService service = new DataSourcesBootstrapService(new ClassPathResource("querylibrary/bootstrap/test-data-sources.yaml"), dataSourceDao);
+        service.bootstrapDataSources();
+
+        Assert.assertEquals(2, dataSourceDao.findAll().size());
+
+        DataSource h2 = dataSourceDao.getByName("H2");
+
+        Map<String, String> h2Properties = h2.getDataSourceProperties()
+                .stream()
+                .collect(Collectors.toMap(DataSourceProperty::getProperty, DataSourceProperty::getValue));
+
+        Assert.assertEquals("H2", h2.getName());
+        Assert.assertEquals("H2 data source", h2.getDescription());
+        Assert.assertEquals(DataProviderType.JDBC, h2.getType());
+        Assert.assertEquals("user", h2Properties.get("username"));
+        Assert.assertEquals("secret", h2Properties.get("password"));
+    }
+
+    @Test(expected = ConstraintViolationException.class)
+    public void testInvalidBootstrapDataSources() throws Exception {
+        DataSourcesBootstrapService service = new DataSourcesBootstrapService(new ClassPathResource("querylibrary/bootstrap/test-data-sources-invalid.yaml"), dataSourceDao);
+        service.bootstrapDataSources();
+    }
+}

--- a/env-monitor/env-monitor-module/src/test/java/org/envtools/monitor/module/querylibrary/services/bootstrap/QueryBootstrapTestConfiguration.java
+++ b/env-monitor/env-monitor-module/src/test/java/org/envtools/monitor/module/querylibrary/services/bootstrap/QueryBootstrapTestConfiguration.java
@@ -1,0 +1,18 @@
+package org.envtools.monitor.module.querylibrary.services.bootstrap;
+
+/**
+ * Created by IAvdeev on 12.01.2017.
+ */
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Configuration for defining ZipArchiveBootstrapService as bean in bootstrap-test-context.xml
+ */
+@ImportResource("classpath:querylibrary/bootstrap/bootstrap-test-context.xml")
+@Configuration
+@ContextConfiguration()
+public class QueryBootstrapTestConfiguration {
+}

--- a/env-monitor/env-monitor-module/src/test/resources/querylibrary/bootstrap/bootstrap-test-context.xml
+++ b/env-monitor/env-monitor-module/src/test/resources/querylibrary/bootstrap/bootstrap-test-context.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <context:property-placeholder location="querylibrary/bootstrap/bootstrap-test.properties" system-properties-mode="OVERRIDE"/>
+
+    <bean id="querylibrary.bootstrapper.zip" class="org.envtools.monitor.module.querylibrary.services.bootstrap.ZipArchiveBootstrapService"/>
+    <bean id="querylibrary.bootstrapper.sql" class="org.envtools.monitor.module.querylibrary.services.bootstrap.SqlFileBootstrapService"/>
+
+</beans>

--- a/env-monitor/env-monitor-module/src/test/resources/querylibrary/bootstrap/bootstrap-test.properties
+++ b/env-monitor/env-monitor-module/src/test/resources/querylibrary/bootstrap/bootstrap-test.properties
@@ -1,0 +1,14 @@
+#querylibrary.zip_bootstrapper.location=src/test/resources/querylibrary/bootstrap/positive-test-root
+querylibrary.zip_bootstrapper.location=src/test/resources/querylibrary/bootstrap/Orders.zip
+
+querylibrary.sql_bootstrapper.location=aghm
+
+querylibrary.data_source_bootstrapper.location=querylibrary/bootstrap/data_sources.yaml
+
+log4j.logger.org.envtools.monitor.module.querylibrary.services.bootstrap.ZipArchiveBootstrapService=DEBUG
+
+# logs the SQL statements
+log4j.logger.org.hibernate.SQL=DEBUG
+
+# Logs the JDBC parameters passed to a query
+log4j.logger.org.hibernate.type=TRACE

--- a/env-monitor/env-monitor-module/src/test/resources/querylibrary/bootstrap/test-data-sources-invalid.yaml
+++ b/env-monitor/env-monitor-module/src/test/resources/querylibrary/bootstrap/test-data-sources-invalid.yaml
@@ -1,0 +1,2 @@
+-
+  description: H2 data source

--- a/env-monitor/env-monitor-module/src/test/resources/querylibrary/bootstrap/test-data-sources.yaml
+++ b/env-monitor/env-monitor-module/src/test/resources/querylibrary/bootstrap/test-data-sources.yaml
@@ -1,0 +1,10 @@
+-
+  name: H2
+  description: H2 data source
+  username: user
+  password: secret
+  type: JDBC
+-
+  name: H3
+  type: JDBC
+

--- a/env-monitor/env-monitor-ui/pom.xml
+++ b/env-monitor/env-monitor-ui/pom.xml
@@ -89,9 +89,7 @@
                 <includes>
                     <include>**/static/scripts.js</include>
                     <include>**/static/styles.css</include>
-                    <include>**/sql/sampledb.sql</include>
-                    <include>**/sql/test_fill_c_q.sql</include>
-                    <include>**/sql/queries.zip</include>
+                    <include>**/sql/*</include>
                     <include>**/static/fonts/*</include>
                     <include>**/static/images/</include>
                     <include>**/static/app/modules/**/templates/**/*.html</include>

--- a/env-monitor/env-monitor-ui/src/main/resources/application.properties
+++ b/env-monitor/env-monitor-ui/src/main/resources/application.properties
@@ -17,6 +17,8 @@ querylibrary.zip_bootstrapper.location=classpath:sql/queries.zip
 #querylibrary.bootstrapper=org.envtools.monitor.module.querylibrary.services.bootstrap.SqlFileBootstrapService
 #querylibrary.sql_bootstrapper.location=classpath:sql/test_fill_c_q.sql
 
+querylibrary.data_sources_bootstrapper.location=classpath:sql/data-sources.yaml
+
 #hosts.list=some_host, inactive_host
 hosts.list=shell.xShellz.com
 

--- a/env-monitor/env-monitor-ui/src/main/resources/sql/data-sources.yaml
+++ b/env-monitor/env-monitor-ui/src/main/resources/sql/data-sources.yaml
@@ -1,0 +1,9 @@
+default:
+  name: default
+  description: Default H2 in-memory database
+  type:            JDBC
+  driverClassName: org.h2.Driver
+  url: "jdbc:h2:file:./h2_data;MVCC=TRUE;DB_CLOSE_ON_EXIT=FALSE;FILE_LOCK=NO"
+  username: sa
+  password: sa
+

--- a/env-monitor/pom.xml
+++ b/env-monitor/pom.xml
@@ -44,12 +44,13 @@
         <org.testng.version>6.9.8</org.testng.version>
         <com.google.guava.version>18.0</com.google.guava.version>
         <commons-beanutils.version>1.9.2</commons-beanutils.version>
-        <com.fasterxml.jackson.core.version>2.6.2</com.fasterxml.jackson.core.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <org.codehaus.jackson.version>1.9.2</org.codehaus.jackson.version>
         <org.json.version>20150729</org.json.version>
         <net.sf.json-lib.version>2.2.3</net.sf.json-lib.version>
-
+        <javax.el.version>2.2.4</javax.el.version>
+        <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
+        <validation-api.version>1.1.0.Final</validation-api.version>
+        <jackson.version>2.6.2</jackson.version>
     </properties>
 
     <dependencies>
@@ -124,6 +125,23 @@
                 <artifactId>unitils-core</artifactId>
                 <version>3.4.2</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
 
         </dependencies>
 


### PR DESCRIPTION
- Replace deprecated org.codehouse.jackson.map.ObjectMapper to newer org.fastxml
- Pull jackson dependency versions to parent pom
- Add JSR 303 Validation for DataSources DAO