### PR TITLE
Fix error `Failure to find com.oracle:ojdbc6:jar:11.2.0.3 `

### DIFF
--- a/env-monitor/env-monitor-module/pom.xml
+++ b/env-monitor/env-monitor-module/pom.xml
@@ -130,4 +130,19 @@
             <version>11.2.0.3</version>
         </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>lib</id>
+            <name>lib</name>
+            <releases>
+                <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <url>file://${project.basedir}/src/main/lib</url>
+        </repository>
+    </repositories>
 </project>

--- a/env-monitor/pom.xml
+++ b/env-monitor/pom.xml
@@ -144,19 +144,5 @@
         </dependencies>
     </dependencyManagement>
 
-    <repositories>
-        <repository>
-            <id>lib</id>
-            <name>lib</name>
-            <releases>
-                <enabled>true</enabled>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <url>file://${project.basedir}/env-monitor-module/src/main/lib</url>
-        </repository>
-    </repositories>
 
 </project>


### PR DESCRIPTION
`${project.basedir}` in parent pom was pointing on current project, not directory of parent pom